### PR TITLE
Force odbc include and lib if no option given

### DIFF
--- a/apr-util.rb
+++ b/apr-util.rb
@@ -33,7 +33,18 @@ class AprUtil < Formula
     args << "--with-pgsql=#{Formula["postgresql"].opt_prefix}" if build.with? "postgresql"
     args << "--with-mysql=#{Formula["mysql"].opt_prefix}" if build.with? "mysql"
     args << "--with-freetds=#{Formula["freetds"].opt_prefix}" if build.with? "freetds"
-    args << "--with-odbc=#{Formula["unixodbc"].opt_prefix}" if build.with? "unixodbc"
+    if build.with? "unixodbc"
+      args << "--with-odbc=#{Formula["unixodbc"].opt_prefix}"
+    else
+      system "which", "odbc_config"
+      if $?.success?
+        odbc_config_inc = `odbc_config --include-prefix`
+        odbc_config_lib = `odbc_config --lib-prefix`
+        args << "--with-odbc"
+        args << "--with-odbc-include=#{odbc_config_inc}"
+        args << "--with-odbc=#{odbc_config_lib}"
+      end
+    end
 
     if build.with? "openldap"
       args << "--with-ldap"


### PR DESCRIPTION
On Red Hat 7.4 and Homebrew 2.1.7, apr-util fails building because
it cannot find 'sql.h' if no options like --with-mysql is given.
We test if odbc_config exists and then we retrieve the correct path
for the lib and the include files